### PR TITLE
Allow to save GitHub configurations

### DIFF
--- a/Pipeliner/Common/Config.swift
+++ b/Pipeliner/Common/Config.swift
@@ -12,4 +12,5 @@ struct Config: Codable, Identifiable, Hashable {
     let projectId: String
     let token: String
     let repositoryName: String
+    let serviceType: ServiceType
 }

--- a/Pipeliner/Common/ServiceTypeEnum.swift
+++ b/Pipeliner/Common/ServiceTypeEnum.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-enum ServiceType: String, CaseIterable {
+enum ServiceType: String, CaseIterable, Codable {
     case GITLAB = "GITLAB"
     case GITHUB = "GITHUB"
     

--- a/Pipeliner/ContentView.swift
+++ b/Pipeliner/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
 
     
     private func isFormValid() -> Bool {
-        if projectId.isEmpty {
+        if self.selection != .GITHUB && projectId.isEmpty {
             return false
         }
 
@@ -76,8 +76,10 @@ struct ContentView: View {
                     }
                 }
                 Button(action: {
-                    if let projectName = pipelinerService.getProjectName(baseUrl: baseUrl, projectId: projectId, token: token) {
-                        configurations =  ConfigurationService.addConfiguration(config: Config(id: UUID().uuidString, baseUrl: baseUrl, projectId: projectId, token: token, repositoryName: projectName))
+                    if let config = try? pipelinerService.getConfig(
+                        self.selection, baseUrl: self.baseUrl, projectId: self.projectId, token: self.token) {
+
+                        configurations =  ConfigurationService.addConfiguration(config: config)
                         pipelines = pipelinerService.getPipelines(pipelineCount: 10)
                         WidgetCenter.shared.reloadAllTimelines()
 

--- a/Pipeliner/ContentView.swift
+++ b/Pipeliner/ContentView.swift
@@ -28,6 +28,7 @@ struct ContentView: View {
 
     
     private func isFormValid() -> Bool {
+        // GitHub service doesn't use projectId
         if self.selection != .GITHUB && projectId.isEmpty {
             return false
         }

--- a/Pipeliner/PipelinerService.swift
+++ b/Pipeliner/PipelinerService.swift
@@ -8,20 +8,23 @@
 import Foundation
 
 class PipelinerService {
-    internal let gitLabService: GitLabService
     internal let dateService: DateService
-    
+    private let resolver = ServiceResolver()
+
     init() {
-        self.gitLabService = GitLabService()
         self.dateService = DateService()
     }
     
-    func getProjectName(baseUrl: String, projectId: String, token: String) -> String? {
-        do {
-            return try gitLabService.getProjectName(baseUrl: baseUrl, projectId: projectId, token: token)
-        } catch  {
-            return nil
-        }
+    func getConfig(_ serviceType: ServiceType, baseUrl: String, projectId: String, token: String) throws -> Config {
+        let service = self.resolver.resolve(serviceType)
+        let projectName = try service.getProjectName(baseUrl: baseUrl, projectId: projectId, token: token)
+        return Config(
+            id: UUID().uuidString,
+            baseUrl: baseUrl,
+            projectId: projectId,
+            token: token,
+            repositoryName: projectName,
+            serviceType: serviceType)
     }
 
     func getPipelines(pipelineCount: Int) -> [PipelineResult]{
@@ -36,7 +39,8 @@ class PipelinerService {
             var pipelinesWithRepoName: [PipelineWithRepoName] = []
             //Get pipelines from API
             for config in configs {
-                let pipelines = try gitLabService.getPipelines(config: config, pipelineCount: pipelineCountPerRepo)
+                let service = self.resolver.resolve(config.serviceType)
+                let pipelines = try service.getPipelines(config: config, pipelineCount: pipelineCountPerRepo)
                 for pipeline in pipelines {
                     pipelinesWithRepoName.append(PipelineWithRepoName(pipeline: pipeline, name: config.repositoryName, date: try dateService.parse(date: pipeline.updated_at)))
                 }
@@ -107,5 +111,24 @@ class ConfigurationService {
             }
         }
         return []
+    }
+}
+
+private struct ServiceResolver {
+    private let gitHubService: GitHubService
+    private let gitLabService: GitLabService
+
+    init() {
+        self.gitHubService = GitHubService()
+        self.gitLabService = GitLabService()
+    }
+
+    func resolve(_ serviceType: ServiceType) -> IService {
+        switch serviceType {
+        case .GITHUB:
+            return self.gitHubService
+        case .GITLAB:
+            return self.gitLabService
+        }
     }
 }


### PR DESCRIPTION
I've just played around and found there is no way to save a GitHub configuration, so I've added a way (not sure what issue number is it though).
Please note that a new property in the `Config` might brake decoding of previously saved configurations. There are no test target in the project, if you add one, I can add coverage for decoding and make sure it's compatible after my changes.