### PR TITLE
Fixed decoding and rendering of status for GitHub configurations

### DIFF
--- a/Pipeliner/Common/Config.swift
+++ b/Pipeliner/Common/Config.swift
@@ -12,4 +12,5 @@ struct Config: Codable, Identifiable, Hashable {
     let projectId: String
     let token: String
     let repositoryName: String
+    let serviceType: ServiceType
 }

--- a/Pipeliner/Common/Pipeline.swift
+++ b/Pipeliner/Common/Pipeline.swift
@@ -6,11 +6,11 @@
 //
 
 import Foundation
-struct Pipeline: Codable, Identifiable {
+struct Pipeline: Decodable, Identifiable {
     public let id: Int
     let sha: String
     let ref: String
-    let status: String
+    let status: PipelineStatus
     let created_at: String
     let updated_at: String
     let web_url: String

--- a/Pipeliner/Common/PipelineStatus.swift
+++ b/Pipeliner/Common/PipelineStatus.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-public enum PipelineStatus: String {
+public enum PipelineStatus: String, Decodable {
     case SUCCESS = "success"
     case FAILED = "failed"
 }

--- a/Pipeliner/Common/ServiceTypeEnum.swift
+++ b/Pipeliner/Common/ServiceTypeEnum.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-enum ServiceType: String, CaseIterable {
+enum ServiceType: String, CaseIterable, Codable {
     case GITLAB = "GITLAB"
     case GITHUB = "GITHUB"
     

--- a/Pipeliner/ContentView.swift
+++ b/Pipeliner/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
 
     
     private func isFormValid() -> Bool {
-        if projectId.isEmpty {
+        if self.selection != .GITHUB && projectId.isEmpty {
             return false
         }
 
@@ -76,8 +76,10 @@ struct ContentView: View {
                     }
                 }
                 Button(action: {
-                    if let projectName = pipelinerService.getProjectName(baseUrl: baseUrl, projectId: projectId, token: token) {
-                        configurations =  ConfigurationService.addConfiguration(config: Config(id: UUID().uuidString, baseUrl: baseUrl, projectId: projectId, token: token, repositoryName: projectName))
+                    if let config = try? pipelinerService.getConfig(
+                        self.selection, baseUrl: self.baseUrl, projectId: self.projectId, token: self.token) {
+
+                        configurations =  ConfigurationService.addConfiguration(config: config)
                         pipelines = pipelinerService.getPipelines(pipelineCount: 10)
                         WidgetCenter.shared.reloadAllTimelines()
 

--- a/Pipeliner/ContentView.swift
+++ b/Pipeliner/ContentView.swift
@@ -28,6 +28,7 @@ struct ContentView: View {
 
     
     private func isFormValid() -> Bool {
+        // GitHub service doesn't use projectId
         if self.selection != .GITHUB && projectId.isEmpty {
             return false
         }

--- a/Pipeliner/GitHub/GitHubService.swift
+++ b/Pipeliner/GitHub/GitHubService.swift
@@ -35,21 +35,9 @@ class GitHubService: IService {
         request.setValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
         request.setValue("bearer \(config.token)", forHTTPHeaderField:"Authorization")
         let data = try await(httpService.getData(request: request))
-        let workflows = try JSONDecoder().decode(Workflows.self, from: data)
-        
-        var pipelines = [Pipeline]()
-        
-        workflows.workflow_runs.forEach {
-            pipelines.append(Pipeline(
-                                id: $0.id,
-                                sha: $0.head_sha,
-                                ref: $0.repository.html_url,
-                                status: $0.status,
-                                created_at: $0.created_at,
-                                updated_at: $0.updated_at,
-                                web_url: $0.html_url))
-        }
-        
-        return pipelines
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let workflows = try decoder.decode(Workflows.self, from: data)
+        return workflows.workflowRuns.map(Pipeline.init)
     }
 }

--- a/Pipeliner/GitHub/Workflow.swift
+++ b/Pipeliner/GitHub/Workflow.swift
@@ -8,20 +8,94 @@
 import Foundation
 
 struct Workflows: Decodable {
-    var total_count: Int
-    var workflow_runs: [Workflow]
+    let workflowRuns: [Workflow]
 }
 
-struct Workflow: Codable, Identifiable {
+struct Workflow: Decodable, Identifiable {
+    enum Status {
+        enum Conclusion: String, Decodable {
+            case actionRequired
+            case cancelled
+            case failure
+            case neutral
+            case skipped
+            case stale
+            case success
+            case timedOut
+        }
+
+        case completed(Conclusion)
+        case inProgress
+        case queued
+    }
+
+    private enum CodingKeys: CodingKey {
+        case conclusion
+        case createdAt
+        case headSha
+        case htmlUrl
+        case id
+        case repository
+        case status
+        case updatedAt
+    }
+
     public let id: Int
-    let head_sha: String
-    let status: String
-    let created_at: String
-    let updated_at: String
-    let html_url: String
+    let sha: String
+    let status: Status
+    let createdAt: String
+    let updatedAt: String
+    let url: String
     let repository: Repository
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.createdAt = try container.decode(String.self, forKey: .createdAt)
+        self.id = try container.decode(Int.self, forKey: .id)
+        self.repository = try container.decode(Repository.self, forKey: .repository)
+        self.sha = try container.decode(String.self, forKey: .headSha)
+        self.updatedAt = try container.decode(String.self, forKey: .updatedAt)
+        self.url = try container.decode(String.self, forKey: .htmlUrl)
+
+        let status = try container.decode(String.self, forKey: .status)
+        switch status {
+        case "completed":
+            let conclusion = try container.decode(Status.Conclusion.self, forKey: .conclusion)
+            self.status = .completed(conclusion)
+        case "in_progress":
+            self.status = .inProgress
+        case "queued":
+            self.status = .queued
+        default:
+            let errorDescription = "[\(status)] is not recognized as status value"
+            throw DecodingError.typeMismatch(
+                Status.self, .init(codingPath: decoder.codingPath, debugDescription: errorDescription))
+        }
+    }
+}
+
+extension Pipeline {
+    init(_ workflow: Workflow) {
+        self.id = workflow.id
+        self.sha = workflow.sha
+        self.ref = workflow.repository.htmlUrl
+        self.status = workflow.status.toPipelineStatus()
+        self.created_at = workflow.createdAt
+        self.updated_at = workflow.updatedAt
+        self.web_url = workflow.url
+    }
+}
+
+private extension Workflow.Status {
+    func toPipelineStatus() -> PipelineStatus {
+        if case .completed(let conclusion) = self, case .success = conclusion {
+            return .SUCCESS
+        }
+
+        return .FAILED
+    }
 }
 
 struct Repository: Codable {
-    let html_url: String
+    let htmlUrl: String
 }

--- a/Pipeliner/PipelinerService.swift
+++ b/Pipeliner/PipelinerService.swift
@@ -8,20 +8,23 @@
 import Foundation
 
 class PipelinerService {
-    internal let gitLabService: GitLabService
     internal let dateService: DateService
-    
+    private let resolver = ServiceResolver()
+
     init() {
-        self.gitLabService = GitLabService()
         self.dateService = DateService()
     }
     
-    func getProjectName(baseUrl: String, projectId: String, token: String) -> String? {
-        do {
-            return try gitLabService.getProjectName(baseUrl: baseUrl, projectId: projectId, token: token)
-        } catch  {
-            return nil
-        }
+    func getConfig(_ serviceType: ServiceType, baseUrl: String, projectId: String, token: String) throws -> Config {
+        let service = self.resolver.resolve(serviceType)
+        let projectName = try service.getProjectName(baseUrl: baseUrl, projectId: projectId, token: token)
+        return Config(
+            id: UUID().uuidString,
+            baseUrl: baseUrl,
+            projectId: projectId,
+            token: token,
+            repositoryName: projectName,
+            serviceType: serviceType)
     }
 
     func getPipelines(pipelineCount: Int) -> [PipelineResult]{
@@ -36,7 +39,8 @@ class PipelinerService {
             var pipelinesWithRepoName: [PipelineWithRepoName] = []
             //Get pipelines from API
             for config in configs {
-                let pipelines = try gitLabService.getPipelines(config: config, pipelineCount: pipelineCountPerRepo)
+                let service = self.resolver.resolve(config.serviceType)
+                let pipelines = try service.getPipelines(config: config, pipelineCount: pipelineCountPerRepo)
                 for pipeline in pipelines {
                     pipelinesWithRepoName.append(PipelineWithRepoName(pipeline: pipeline, name: config.repositoryName, date: try dateService.parse(date: pipeline.updated_at)))
                 }
@@ -107,5 +111,24 @@ class ConfigurationService {
             }
         }
         return []
+    }
+}
+
+private struct ServiceResolver {
+    private let gitHubService: GitHubService
+    private let gitLabService: GitLabService
+
+    init() {
+        self.gitHubService = GitHubService()
+        self.gitLabService = GitLabService()
+    }
+
+    func resolve(_ serviceType: ServiceType) -> IService {
+        switch serviceType {
+        case .GITHUB:
+            return self.gitHubService
+        case .GITLAB:
+            return self.gitLabService
+        }
     }
 }

--- a/Pipeliner/PipelinerService.swift
+++ b/Pipeliner/PipelinerService.swift
@@ -53,7 +53,15 @@ class PipelinerService {
             for pipeline in pipelinesWithRepoName {
                 let duration = try dateService.format(from: try dateService.parse(date: pipeline.pipeline.created_at), to: try dateService.parse(date: pipeline.pipeline.updated_at))
                 let age = try dateService.format(from: try dateService.parse(date: pipeline.pipeline.updated_at), to: Date())
-                results.append(PipelineResult(id: pipeline.pipeline.id, ref: pipeline.pipeline.ref, status: pipeline.pipeline.status == PipelineStatus.SUCCESS.rawValue ? PipelineStatus.SUCCESS : PipelineStatus.FAILED, duration: duration, age: age, url: pipeline.pipeline.web_url, repositoryName: pipeline.repositoryName))
+                let result = PipelineResult(
+                    id: pipeline.pipeline.id,
+                    ref: pipeline.pipeline.ref,
+                    status: pipeline.pipeline.status,
+                    duration: duration,
+                    age: age,
+                    url: pipeline.pipeline.web_url,
+                    repositoryName: pipeline.repositoryName)
+                results.append(result)
             }
             //Return rigth number of pipelines
             return results.enumerated().filter { $0.offset < pipelineCount }.map { $0.element }


### PR DESCRIPTION
This should follow #24 (the branch includes changes for both PRs)

* Decode `status` as `PipelineStatus` directly
* Properties in GitHub models are updated to be camelCase (following Swift conventions) with usage of `KeyDecodingStrategy.convertFromSnakeCase`